### PR TITLE
allow elem similarity matrix to be a df or filepath

### DIFF
--- a/src/gridrdf/earth_mover_distance.py
+++ b/src/gridrdf/earth_mover_distance.py
@@ -18,14 +18,15 @@ import numpy as np
 import pandas as pd
 import argparse
 from tqdm import tqdm
+
 try:
     from pymatgen import Structure
 except ImportError:
-    from pymatgen.core.structure import Structure   
+    from pymatgen.core.structure import Structure
 try:
     from pymatgen import Lattice
 except ImportError:
-    from pymatgen.core.lattice import Lattice   
+    from pymatgen.core.lattice import Lattice
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from scipy import spatial
 from scipy.sparse import coo_matrix
@@ -35,9 +36,9 @@ import warnings
 # Used for faster version of EMD
 import numba as nb
 
-# the wasserstein distance in scipy treats frequencies of each bin as a value, 
-# and then builds the distributions from those values and computes the distance. 
-# You can either simply pass the values that you create histograms from 
+# the wasserstein distance in scipy treats frequencies of each bin as a value,
+# and then builds the distributions from those values and computes the distance.
+# You can either simply pass the values that you create histograms from
 # or pass mid points of bins as values and frequencies as weights
 # here the later method is used
 from scipy.stats import wasserstein_distance
@@ -50,69 +51,77 @@ from scipy.stats import wasserstein_distance
 from pyemd import emd, emd_with_flow
 
 
-
 from .data_io import rdf_read, rdf_read_parallel
 from .data_explore import rdf_trim, rdf_flatten
 import gridrdf.composition
 from .composition import composition_one_hot, element_indice
 from .misc import int_or_str
 
+
 def emd_formula_example():
-    '''
-    Test the Earth Mover's Distance (EMD) using similarity matrix 
+    """
+    Test the Earth Mover's Distance (EMD) using similarity matrix
     against the EMD in the literature
     https://github.com/lrcfmd/ElMD/
-    '''
-    
+    """
+
     try:
         from ElMD import ElMD
     except:
-        print('Element-EMD module not installed')
-        
+        print("Element-EMD module not installed")
+
     elem_emd = ElMD()
-        
-    comp1 = elem_emd._gen_vector('Li0.7Al0.3Ti1.7P3O12')
-    comp2 = elem_emd._gen_vector('La0.57Li0.29TiO3')
+
+    comp1 = elem_emd._gen_vector("Li0.7Al0.3Ti1.7P3O12")
+    comp2 = elem_emd._gen_vector("La0.57Li0.29TiO3")
     pettifor_emd = elem_emd._EMD(comp1, comp2)
 
-    comp1_reindex = pd.DataFrame(comp1, index=gridrdf.composition.modified_pettifor).reindex(index=gridrdf.composition.pettifor)
-    comp2_reindex = pd.DataFrame(comp2, index=gridrdf.composition.modified_pettifor).reindex(index=gridrdf.composition.pettifor)
+    comp1_reindex = pd.DataFrame(
+        comp1, index=gridrdf.composition.modified_pettifor
+    ).reindex(index=gridrdf.composition.pettifor)
+    comp2_reindex = pd.DataFrame(
+        comp2, index=gridrdf.composition.modified_pettifor
+    ).reindex(index=gridrdf.composition.pettifor)
 
-    dist_matrix = pd.read_csv('similarity_matrix.csv', index_col='ionA').values
-    dist_matrix = dist_matrix.copy(order='C')
+    dist_matrix = pd.read_csv("similarity_matrix.csv", index_col="ionA").values
+    dist_matrix = dist_matrix.copy(order="C")
 
-    em = emd_with_flow(comp1_reindex.values[:,0], comp2_reindex.values[:,0], dist_matrix)
+    em = emd_with_flow(
+        comp1_reindex.values[:, 0], comp2_reindex.values[:, 0], dist_matrix
+    )
     simi_matrix_emd = em[0]
-    emd_flow = pd.DataFrame(em[1], columns=gridrdf.composition.pettifor, index=gridrdf.composition.pettifor)
-    emd_flow.replace(0, np.nan).to_csv('emd_flow.csv')
+    emd_flow = pd.DataFrame(
+        em[1], columns=gridrdf.composition.pettifor, index=gridrdf.composition.pettifor
+    )
+    emd_flow.replace(0, np.nan).to_csv("emd_flow.csv")
 
 
 def find_same_structure(data):
-    '''
+    """
     Find all pairs of structures that give exactly the same extended RDF
     in a dataset
-    
+
     Args:
         data: json data containing structures information and MP-ID(typically CIFs)
     Return:
         A nested list of MP-IDs with same structures, grouped by space group number
-    '''
+    """
     # group the structures (without composition information) using space group
     # first make a dict with keys are space group numbers
     sg_grouped_structs = {}
     for sg_num in range(230, 0, -1):
         sg_grouped_structs[sg_num] = {}
-    
+
     for d in data:
-        struct = Structure.from_str(d['cif'], fmt='cif')
+        struct = Structure.from_str(d["cif"], fmt="cif")
         # remove the composition information by setting all elements to X
         # as currently extended RDF does not have composition information
         for elem in struct.symbol_set:
-            struct[elem] = 'H'
+            struct[elem] = "H"
 
         sg_num = struct.get_space_group_info()[1]
-        sg_grouped_structs[sg_num][d['task_id']] = struct 
-    
+        sg_grouped_structs[sg_num][d["task_id"]] = struct
+
     sc = StructureMatcher(ltol=0.05, stol=0.05, scale=False)
     match_list = {}
     for sg_num, structs in sg_grouped_structs.items():
@@ -134,7 +143,7 @@ def find_same_structure(data):
             for mp_id in same_struct_list:
                 structs.pop(mp_id)
 
-        '''
+        """
         if len(structs) > 0:
             match_list[sg_num] = []
             for i, (task_id_1, struct_1) in enumerate(tqdm(structs.items(), mininterval=60)):
@@ -146,25 +155,25 @@ def find_same_structure(data):
                             match_list[sg_num].append([task_id_1, task_id_2])
                             print(task_id_1, task_id_2)
                             break
-        '''
+        """
     return match_list
 
 
 def find_same_rdf(all_rdf, data):
-    '''
+    """
     Find all exactly the same extended RDF in a dataset
-    
+
     Args:
         all_rdf: all the trimmed and flatten rdf
         data: json data containing structures information and MP-ID
     Return:
         A list of pairs of MP-IDs
-    '''
+    """
     # make all_rdf a dict with keys of mp-ids
     rdfs = {}
     for i, d in enumerate(data):
-        rdfs[d['task_id']] = all_rdf[i]
-    
+        rdfs[d["task_id"]] = all_rdf[i]
+
     match_list = []
     while len(rdfs) != 0:
         rdf_1 = list(rdfs.values())[0]
@@ -180,33 +189,32 @@ def find_same_rdf(all_rdf, data):
 
 
 def analysis_emd_100():
-    '''
-    '''
+    """ """
     df = pd.DataFrame([], index=np.linspace(0.2, 0.6, 5))
-    for i in ['small', 'middle', 'large']:
+    for i in ["small", "middle", "large"]:
         for thresh in np.linspace(0.2, 0.6, 5):
-            data = np.loadtxt(i + '_sample_' + str(thresh), delimiter=' ')
+            data = np.loadtxt(i + "_sample_" + str(thresh), delimiter=" ")
             for val in range(4):
                 df.loc[thresh, i + str(val)] = np.count_nonzero(data == val)
-    df.to_csv('analysis.csv')
+    df.to_csv("analysis.csv")
 
 
 def dist_matrix_1d(nbin=100):
-    '''
+    """
     Generate distance matrix for earth mover's distance use
-    '''
+    """
 
-    #dist_matrix = np.abs(np.subtract.outer(range(nbin), range(nbin)))
+    # dist_matrix = np.abs(np.subtract.outer(range(nbin), range(nbin)))
     dist_matrix = pd.DataFrame()
     for x in range(nbin):
         for y in range(nbin):
-            dist_matrix.loc[x, y] = abs(x-y)
+            dist_matrix.loc[x, y] = abs(x - y)
     return dist_matrix.values
 
 
-def nn_bulk_modulus_single(baseline_id, data, n_nn=1, emd='both'):
-    '''
-    Using the calucated EMD values and find the n nearest neighbor to estimate 
+def nn_bulk_modulus_single(baseline_id, data, n_nn=1, emd="both"):
+    """
+    Using the calucated EMD values and find the n nearest neighbor to estimate
     bulk modulus
 
     Args:
@@ -223,29 +231,33 @@ def nn_bulk_modulus_single(baseline_id, data, n_nn=1, emd='both'):
         mp-id of the nearest neighbor
         Estimation of the bulk modulus
         EMD distance between the nearest neighbor and baseline
-    '''
+    """
     df_mp = pd.DataFrame.from_dict(data)
-    df_mp = df_mp.set_index('task_id')
+    df_mp = df_mp.set_index("task_id")
 
-    if emd == 'rdf' or emd == 'both':
-        rdf_emd_file = os.path.join(sys.path[0], '../rdf_emd/', baseline_id + '_emd.csv')
+    if emd == "rdf" or emd == "both":
+        rdf_emd_file = os.path.join(
+            sys.path[0], "../rdf_emd/", baseline_id + "_emd.csv"
+        )
         rdf_emd = pd.read_csv(rdf_emd_file, index_col=0)
 
-    if emd == 'compos' or emd == 'both':
-        compos_emd_file = os.path.join(sys.path[0], '../compos_emd/', baseline_id + '_compos_emd.csv')
+    if emd == "compos" or emd == "both":
+        compos_emd_file = os.path.join(
+            sys.path[0], "../compos_emd/", baseline_id + "_compos_emd.csv"
+        )
         compos_emd = pd.read_csv(compos_emd_file, index_col=0)
 
     # now add two emds to give a finally emd, need new method
-    if emd == 'both':
+    if emd == "both":
         total_emd = rdf_emd.add(compos_emd)
-    elif emd == 'rdf':
+    elif emd == "rdf":
         total_emd = rdf_emd
-    elif emd == 'compos':
+    elif emd == "compos":
         total_emd = compos_emd
-        
+
     nn_mps = total_emd.nsmallest(n_nn + 1, baseline_id)
 
-    # sometimes there are other structures have zero emd with 
+    # sometimes there are other structures have zero emd with
     # the baseline_id, so it is not always the first row is the baseline_id
     # so use drop instead of removing the first row
     try:
@@ -256,19 +268,25 @@ def nn_bulk_modulus_single(baseline_id, data, n_nn=1, emd='both'):
 
     aver_modul = 0
     for task_id in nn_mps.index.values:
-        aver_modul += df_mp['elasticity.K_VRH'][task_id]
+        aver_modul += df_mp["elasticity.K_VRH"][task_id]
 
-    return (baseline_id, df_mp['elasticity.K_VRH'][baseline_id], 
-            nn_mps.index.values[0], aver_modul / n_nn, 
-            nn_mps.values[0][0] )
+    return (
+        baseline_id,
+        df_mp["elasticity.K_VRH"][baseline_id],
+        nn_mps.index.values[0],
+        aver_modul / n_nn,
+        nn_mps.values[0][0],
+    )
 
 
-def nn_bulk_modulus_matrix_add(data, nn=1, simi_dir = '.', simi_matrix=['extended_rdf_emd'], scale=True):
-    '''
+def nn_bulk_modulus_matrix_add(
+    data, nn=1, simi_dir=".", simi_matrix=["extended_rdf_emd"], scale=True
+):
+    """
     Deprecated. The adding similarity matrix is worse than currently used
-    Using the calucated EMD values and find the n nearest neighbor to estimate 
+    Using the calucated EMD values and find the n nearest neighbor to estimate
     bulk modulus. If two EMD matrix are used, then add the values of the two matrix
-    
+
     Args:
         data: mp json data from file
         nn: number of nearest neighbors
@@ -283,20 +301,24 @@ def nn_bulk_modulus_matrix_add(data, nn=1, simi_dir = '.', simi_matrix=['extende
         Estimation of the bulk modulus
         EMD distance between the nearest neighbor and baseline
         mp-id of the nearest neighbor
-    '''
+    """
 
-    warnings.warn('`nn_bulk_modulus_matrix_add` is deprecated and will be removed', DeprecationWarning)
+    warnings.warn(
+        "`nn_bulk_modulus_matrix_add` is deprecated and will be removed",
+        DeprecationWarning,
+    )
 
     # read the modulus data and convert to pandas dataframe
     # for the usage of later ground truth and mp ids
     df_mp = pd.DataFrame.from_dict(data)
-    df_mp = df_mp.set_index('task_id')
+    df_mp = df_mp.set_index("task_id")
 
     # read the emd matrix
-    total_emd = pd.DataFrame(np.zeros((len(data), len(data))),
-                            index=df_mp.index, columns=df_mp.index)
-    if 'extended_rdf_emd' in simi_matrix:
-        rdf_emd_file = os.path.join(simi_dir, 'extended_rdf_emd.csv')
+    total_emd = pd.DataFrame(
+        np.zeros((len(data), len(data))), index=df_mp.index, columns=df_mp.index
+    )
+    if "extended_rdf_emd" in simi_matrix:
+        rdf_emd_file = os.path.join(simi_dir, "extended_rdf_emd.csv")
         rdf_emd = pd.read_csv(rdf_emd_file, index_col=0)
         rdf_emd = rdf_emd.fillna(0).add(rdf_emd.transpose().fillna(0))
         if scale:
@@ -304,47 +326,54 @@ def nn_bulk_modulus_matrix_add(data, nn=1, simi_dir = '.', simi_matrix=['extende
         else:
             total_emd = total_emd.add(rdf_emd)
 
-    if 'extended_rdf_cosine' in simi_matrix:
-        rdf_emd_file = os.path.join(simi_dir, 'extended_rdf_cosine.csv')
+    if "extended_rdf_cosine" in simi_matrix:
+        rdf_emd_file = os.path.join(simi_dir, "extended_rdf_cosine.csv")
         rdf_emd = pd.read_csv(rdf_emd_file, index_col=0)
         rdf_emd = rdf_emd.fillna(0).add(rdf_emd.transpose().fillna(0))
         total_emd = total_emd.add(rdf_emd)
 
-    if 'composition_emd' in simi_matrix:
-        compos_emd_file = os.path.join(simi_dir, 'composition_emd.csv')
+    if "composition_emd" in simi_matrix:
+        compos_emd_file = os.path.join(simi_dir, "composition_emd.csv")
         compos_emd = pd.read_csv(compos_emd_file, index_col=0)
         compos_emd = compos_emd.fillna(0).add(compos_emd.transpose().fillna(0))
         total_emd = total_emd.add(compos_emd)
 
     if total_emd.isna().all().sum() > 0:
-        raise IndexError('data file is a different size to distance matrix')
+        raise IndexError("data file is a different size to distance matrix")
 
-    pred_k = pd.DataFrame(index=df_mp.index,
-                        columns=['ground_truth', 'predict_bulk_modulus', 
-                                    'smallest_emd', 'nearest_neighbor'])
+    pred_k = pd.DataFrame(
+        index=df_mp.index,
+        columns=[
+            "ground_truth",
+            "predict_bulk_modulus",
+            "smallest_emd",
+            "nearest_neighbor",
+        ],
+    )
     for baseline_id in df_mp.index.values:
         nn_mps = total_emd[baseline_id].drop(baseline_id).nsmallest(nn)
 
         aver_modul = 0
         for task_id in nn_mps.index.values:
-            aver_modul += df_mp['elasticity.K_VRH'][task_id]
+            aver_modul += df_mp["elasticity.K_VRH"][task_id]
 
         # df.loc index go first, df[] column go first
-        pred_k.loc[baseline_id]['predict_bulk_modulus'] = aver_modul / nn
-        pred_k.loc[baseline_id]['ground_truth'] = df_mp['elasticity.K_VRH'][baseline_id]
-        pred_k.loc[baseline_id]['smallest_emd'] = nn_mps.values[0]
-        pred_k.loc[baseline_id]['nearest_neighbor'] = nn_mps.index.values[0]
-        
+        pred_k.loc[baseline_id]["predict_bulk_modulus"] = aver_modul / nn
+        pred_k.loc[baseline_id]["ground_truth"] = df_mp["elasticity.K_VRH"][baseline_id]
+        pred_k.loc[baseline_id]["smallest_emd"] = nn_mps.values[0]
+        pred_k.loc[baseline_id]["nearest_neighbor"] = nn_mps.index.values[0]
 
     return pred_k
 
 
-def nn_bulk_modulus_matrix_step(data, simi_matrix=['extended_rdf_emd','composition_emd']):
-    '''
-    Using the calucated EMD values and find the n nearest neighbor to estimate 
+def nn_bulk_modulus_matrix_step(
+    data, simi_matrix=["extended_rdf_emd", "composition_emd"]
+):
+    """
+    Using the calucated EMD values and find the n nearest neighbor to estimate
     bulk modulus
 
-    If two similaity matrix is used, first search the nearest neighbors of the first matrix, 
+    If two similaity matrix is used, first search the nearest neighbors of the first matrix,
     if same values are found, then use the second matrix to find which is the nearest
 
     Args:
@@ -360,97 +389,113 @@ def nn_bulk_modulus_matrix_step(data, simi_matrix=['extended_rdf_emd','compositi
         Estimation of the bulk modulus
         EMD distance between the nearest neighbor and baseline
         mp-id of the nearest neighbor
-    '''
+    """
     # read the modulus data and convert to pandas dataframe
     # for the usage of later ground truth and mp ids
     df_mp = pd.DataFrame.from_dict(data)
-    df_mp = df_mp.set_index('task_id')
+    df_mp = df_mp.set_index("task_id")
 
     # read the emd matrix
-    total_emd = pd.DataFrame(np.zeros((len(data), len(data))),
-                            index=df_mp.index, columns=df_mp.index)
-    
-    file_1 = os.path.join(sys.path[0], simi_matrix[0]+'.csv')
+    total_emd = pd.DataFrame(
+        np.zeros((len(data), len(data))), index=df_mp.index, columns=df_mp.index
+    )
+
+    file_1 = os.path.join(sys.path[0], simi_matrix[0] + ".csv")
     simi_mat_1 = pd.read_csv(file_1, index_col=0)
     simi_mat_1 = simi_mat_1.fillna(0).add(simi_mat_1.transpose().fillna(0))
 
-    file_2 = os.path.join(sys.path[0], simi_matrix[1]+'.csv')
+    file_2 = os.path.join(sys.path[0], simi_matrix[1] + ".csv")
     simi_mat_2 = pd.read_csv(file_2, index_col=0)
     simi_mat_2 = simi_mat_2.fillna(0).add(simi_mat_2.transpose().fillna(0))
 
-    pred_k = pd.DataFrame(index=df_mp.index,
-                        columns=['ground_truth', 'predict_bulk_modulus', 
-                                    'emd_1', 'emd_2', 'nearest_neighbor'])
+    pred_k = pd.DataFrame(
+        index=df_mp.index,
+        columns=[
+            "ground_truth",
+            "predict_bulk_modulus",
+            "emd_1",
+            "emd_2",
+            "nearest_neighbor",
+        ],
+    )
     for baseline_id in df_mp.index.values:
         single_emd = simi_mat_1[baseline_id].drop(baseline_id)
         # fount the indice with the smallest value
         nn_idx = single_emd.where(single_emd == single_emd.min()).dropna()
         nn_idx = nn_idx.to_frame()
-        
+
         if len(nn_idx) > 1:
             # if there are multiple structures have the same end,
             # then determine the nearest by considering the second similarity matrix
             new_list = []
             for task_id in nn_idx.index.values:
                 new_list.append(simi_mat_2[baseline_id][task_id])
-            nn_idx['new'] = new_list
-            nn_mps = nn_idx.nsmallest(1, 'new')
+            nn_idx["new"] = new_list
+            nn_mps = nn_idx.nsmallest(1, "new")
         else:
-            nn_idx['new'] = [0]
+            nn_idx["new"] = [0]
             nn_mps = nn_idx
 
         # df.loc index go first, df[] column go first
-        pred_k.loc[baseline_id]['predict_bulk_modulus'] = df_mp['elasticity.K_VRH'][nn_mps.index.values[0]]
-        pred_k.loc[baseline_id]['ground_truth'] = df_mp['elasticity.K_VRH'][baseline_id]
-        pred_k.loc[baseline_id]['emd_1'] = nn_mps.values[0][0]
-        pred_k.loc[baseline_id]['emd_2'] = nn_mps.values[0][1]
-        pred_k.loc[baseline_id]['nearest_neighbor'] = nn_mps.index.values[0]
+        pred_k.loc[baseline_id]["predict_bulk_modulus"] = df_mp["elasticity.K_VRH"][
+            nn_mps.index.values[0]
+        ]
+        pred_k.loc[baseline_id]["ground_truth"] = df_mp["elasticity.K_VRH"][baseline_id]
+        pred_k.loc[baseline_id]["emd_1"] = nn_mps.values[0][0]
+        pred_k.loc[baseline_id]["emd_2"] = nn_mps.values[0][1]
+        pred_k.loc[baseline_id]["nearest_neighbor"] = nn_mps.index.values[0]
 
     return pred_k
 
 
-def composition_similarity(baseline_id, data, index='z_number_78'):
-    '''
+def composition_similarity(baseline_id, data, index="z_number_78"):
+    """
     Calcalate the earth mover's distance between the baseline structure and all others
-    in the dataset 
+    in the dataset
 
     Args:
         data: a pandas dataframe, index is mp-ids, and columns is element symbols
     Return:
         a pandas dataframe of pairwise distance between baseline id and all others
-    '''
+    """
     # define the indice by call element_indice function
     element_indice()
-    
+
     dist = []
-    elem_similarity_file = os.path.join(sys.path[0], 'similarity_matrix.csv')
-    dist_matrix = pd.read_csv(elem_similarity_file, index_col='ionA')
+    elem_similarity_file = os.path.join(sys.path[0], "similarity_matrix.csv")
+    dist_matrix = pd.read_csv(elem_similarity_file, index_col="ionA")
     dist_matrix = 1 / (np.log10(1 / dist_matrix + 1))
 
-    if index == 'pettifor':
-        dist_matrix = dist_matrix.reindex(columns=gridrdf.composition.pettifor, index=gridrdf.composition.pettifor) 
+    if index == "pettifor":
+        dist_matrix = dist_matrix.reindex(
+            columns=gridrdf.composition.pettifor, index=gridrdf.composition.pettifor
+        )
     # the earth mover's distance package need order C and float64 astype('float64')
-    dist_matrix = dist_matrix.values.copy(order='C')
+    dist_matrix = dist_matrix.values.copy(order="C")
 
     compo_emd = pd.DataFrame(columns=[baseline_id])
     mp_id_1 = baseline_id
     for mp_id_2 in tqdm(data.index, mininterval=60):
-        compo_emd.loc[mp_id_2] = emd(data.loc[mp_id_1].values.copy(order='C'), 
-                                    data.loc[mp_id_2].values.copy(order='C'), 
-                                    dist_matrix)
+        compo_emd.loc[mp_id_2] = emd(
+            data.loc[mp_id_1].values.copy(order="C"),
+            data.loc[mp_id_2].values.copy(order="C"),
+            dist_matrix,
+        )
     return compo_emd
 
 
-def composition_similarity_matrix(data, indice=None, index='z_number_78', elem_similarity_file='similarity_matrix.csv'):
-    '''
-    Calcalate pairwise earth mover's distance of all compositions, the composition should be 
-    a 78-element vector, as the elemental similarity_matrix is 78x78 matrix in the order of  
+def composition_similarity_matrix(
+    data, indice=None, index="z_number_78", elem_similarity_file="similarity_matrix.csv"
+):
+    """
+    Calcalate pairwise earth mover's distance of all compositions, the composition should be
+    a 78-element vector, as the elemental similarity_matrix is 78x78 matrix in the order of
     atom numbers
 
     Args:
         data: pandas dataframe of element vectors for all the structures
         index: see function element_indice for details
-            z_number_78: (default) in the order of atomic number, this is default 
+            z_number_78: (default) in the order of atomic number, this is default
                 because the similarity matrix is in this order
             z_number: see periodic_table in function element_indice
             pettifor: see function element_indice for details
@@ -458,42 +503,47 @@ def composition_similarity_matrix(data, indice=None, index='z_number_78', elem_s
             elem_present: the vector only contain the elements presented in the dataset
     Return:
         a pandas dataframe of pairwise EMD with mp-ids as index
-    '''
+    """
     # define the indice by call element_indice function
     element_indice()
 
     # if indice is None, then loop over the whole dataset
     if not indice:
         indice = [0, len(data)]
-    
+
     dist = []
-    dist_matrix = pd.read_csv(elem_similarity_file, index_col='ionA')
+    dist_matrix = pd.read_csv(elem_similarity_file, index_col="ionA")
     dist_matrix = 1 / (np.log10(1 / dist_matrix + 1))
 
-    if index == 'pettifor':
-        dist_matrix = dist_matrix.reindex(columns=gridrdf.composition.pettifor, index=gridrdf.composition.pettifor) 
+    if index == "pettifor":
+        dist_matrix = dist_matrix.reindex(
+            columns=gridrdf.composition.pettifor, index=gridrdf.composition.pettifor
+        )
     # the earth mover's distance package need order C and float64 astype('float64')
-    dist_matrix = dist_matrix.values.copy(order='C')
-    
-    ids = data.iloc[indice[0]:indice[1]].index
-    compo_emd = pd.DataFrame(np.zeros((indice[-1], indice[-1])), index=ids, columns=ids )
+    dist_matrix = dist_matrix.values.copy(order="C")
+
+    ids = data.iloc[indice[0] : indice[1]].index
+    compo_emd = pd.DataFrame(np.zeros((indice[-1], indice[-1])), index=ids, columns=ids)
     for i1 in range(indice[0], indice[1]):
         mp_id_1 = data.index[i1]
         for i2, mp_id_2 in enumerate(data.index):
             if i1 <= i2:
-                emd_value = emd(data.loc[mp_id_1].values.copy(order='C'), 
-                                data.loc[mp_id_2].values.copy(order='C'), 
-                                dist_matrix)
+                emd_value = emd(
+                    data.loc[mp_id_1].values.copy(order="C"),
+                    data.loc[mp_id_2].values.copy(order="C"),
+                    dist_matrix,
+                )
                 compo_emd.loc[mp_id_1, mp_id_2] = emd_value
             else:
                 compo_emd.loc[mp_id_1, mp_id_2] = np.nan
     return compo_emd
 
+
 @nb.njit(parallel=True)
-def _emd_cumsum_row(cumsum_grid_array, index, bin_width, weights = None):
+def _emd_cumsum_row(cumsum_grid_array, index, bin_width, weights=None):
     """Super-fast implementation of EMD with Numba support for an array of structures.
-    
-    WARNING: This algorithm does not do any error checking! It assumes that the input is 
+
+    WARNING: This algorithm does not do any error checking! It assumes that the input is
              a NumPy array of cumulative, normalised grid distributions.
 
     This is optimised to calculate EMD between one GRID and many others in parallel, with
@@ -503,9 +553,9 @@ def _emd_cumsum_row(cumsum_grid_array, index, bin_width, weights = None):
 
     Parameters
     ----------
-    
+
     cumsum_grid_array: np.ndarray, shape (nstructures, ngrid_shells, nbins)
-        Cumulative distributions of normalised GRIDs, stacked into a single 3D tensor. 
+        Cumulative distributions of normalised GRIDs, stacked into a single 3D tensor.
         IMPORTANT: cumulative distributions must all sum to the same value!
 
     index: int
@@ -513,7 +563,7 @@ def _emd_cumsum_row(cumsum_grid_array, index, bin_width, weights = None):
     bin_width : float
         Width of each histogram bin, used to normalise the resulting EMD correctly
     weights: array-like, default None
-        Weighting to apply to each grid shell before computing the mean. If None, equal weighting (1/n_shells) 
+        Weighting to apply to each grid shell before computing the mean. If None, equal weighting (1/n_shells)
         will be applied.
         The weights should be the same length as the number of GRID shells, and should sum to the number of shells (not 1).
 
@@ -521,18 +571,18 @@ def _emd_cumsum_row(cumsum_grid_array, index, bin_width, weights = None):
     Notes
     -----
 
-    As detailed [scipy.stats.wasserstein_distance](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.wasserstein_distance.html), 
+    As detailed [scipy.stats.wasserstein_distance](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.wasserstein_distance.html),
     an equivalent definition of EMD based on cumulative distribution functions is:
 
     $$
     EMD(u,v) = \int_{-\infty}{+\infty}|U - V|
     $$
-    where $u,v$ are probability distributions and $U, V$ are their respectives cumulative distributions. As such, the EMD between 
+    where $u,v$ are probability distributions and $U, V$ are their respectives cumulative distributions. As such, the EMD between
     two GRID representations $(G,H)$ will be
     $$
     EMD(G, H) = \sum_{j=1}^n \left( \frac{\sum_i | G_{j,i} - H_{j,i} |}{max(U)} \times w \right) / n
     $$
-    where the sum over $i$ is for all bins in a given GRID shell (to the same cutoff) and $w$ is the width of each bin. The 
+    where the sum over $i$ is for all bins in a given GRID shell (to the same cutoff) and $w$ is the width of each bin. The
     division by $max(U)$ is needed in cases where $u$ and $v$ are not normalised to sum to 1, for instance when $w < 1$.
     $j$ is the sum across all GRID shells $n$, meaning that the overall EMD is the mean of each shell EMD (currently, this
     may change in future).
@@ -546,10 +596,16 @@ def _emd_cumsum_row(cumsum_grid_array, index, bin_width, weights = None):
         shell_weights = np.ones(cumsum_grid_array.shape[1]) * weights
 
     output = np.zeros(cumsum_grid_array.shape[0])
-    for j in nb.prange(index,cumsum_grid_array.shape[0]):
-        output[j] = np.mean( shell_weights * np.sum(np.abs(cumsum_grid_array[index] - cumsum_grid_array[j]), axis=-1) / np.max(cumsum_grid_array[index]) * bin_width)
-        #output[j] = np.sum(shell_weights)
+    for j in nb.prange(index, cumsum_grid_array.shape[0]):
+        output[j] = np.mean(
+            shell_weights
+            * np.sum(np.abs(cumsum_grid_array[index] - cumsum_grid_array[j]), axis=-1)
+            / np.max(cumsum_grid_array[index])
+            * bin_width
+        )
+        # output[j] = np.sum(shell_weights)
     return output
+
 
 @nb.njit()
 def _EMD_cumsum(cumulative_grid1, cumulative_grid2, bin_width, weights=None):
@@ -564,7 +620,7 @@ def _EMD_cumsum(cumulative_grid1, cumulative_grid2, bin_width, weights=None):
     bin_width: float
         Width of each bin in order to normalise the EMD correctly
     weights: array-like, default None
-        Weighting to apply to each grid shell before computing the mean. If None, equal weighting (1/n_shells) 
+        Weighting to apply to each grid shell before computing the mean. If None, equal weighting (1/n_shells)
         will be applied.
         The weights should be the same length as the number of GRID shells, and should sum to 1.
 
@@ -580,13 +636,21 @@ def _EMD_cumsum(cumulative_grid1, cumulative_grid2, bin_width, weights=None):
     For mathematical explanation see `_EMD_cumsum_row`
 
     """
-    
+
     if weights is None:
         weights = np.ones(cumulative_grid1.shape[0])
-    return np.mean( weights * np.sum(np.abs(cumulative_grid1 - cumulative_grid2), axis=-1) / np.max(cumulative_grid1) * bin_width)
+    return np.mean(
+        weights
+        * np.sum(np.abs(cumulative_grid1 - cumulative_grid2), axis=-1)
+        / np.max(cumulative_grid1)
+        * bin_width
+    )
+
 
 @nb.njit()
-def _flattened_EMD_cumsum(cumulative_grid_flat1, cumulative_grid_flat2, shape, bin_width, weights=None):
+def _flattened_EMD_cumsum(
+    cumulative_grid_flat1, cumulative_grid_flat2, shape, bin_width, weights=None
+):
     """
     Compute EMD between two flattened GRID distributions.
     """
@@ -596,11 +660,14 @@ def _flattened_EMD_cumsum(cumulative_grid_flat1, cumulative_grid_flat2, shape, b
 
     return _EMD_cumsum(grid1, grid2, bin_width, weights)
 
-def super_fast_EMD_matrix(grids,
-                          bin_width,
-                          weighting='constant',
-                          weighting_kwargs={'n':0.0},
-                          results_array = None,):
+
+def super_fast_EMD_matrix(
+    grids,
+    bin_width,
+    weighting="constant",
+    weighting_kwargs={"n": 0.0},
+    results_array=None,
+):
     """
     Efficient parallelised method to compute the matrix of EMD for a collection of GRID representations.
 
@@ -614,9 +681,9 @@ def super_fast_EMD_matrix(grids,
         Width of each GRID bin for correctly normalising EMD
     weighting : str or function
         Weighting to apply to each grid shell when computing the overall EMD, allowing
-        biasing towards short- or long-range similarity. A string argument will use 
+        biasing towards short- or long-range similarity. A string argument will use
         a pre-defined weighting function, or alternatively a callable can be provided in
-        order to compute weightings. If callable, the function should take the number of 
+        order to compute weightings. If callable, the function should take the number of
         shells as input and return an array of values.
         Note that weights should be normalised to sum to the number
         of GRID shells (not 1).
@@ -625,7 +692,7 @@ def super_fast_EMD_matrix(grids,
             'power' : weighting of shell x is 1/x**n (normalised over all shells)
         Default : 'constant' (equal weighting to bins)
     weighting_kwargs : dict
-        Kwargs to use for computing weighting, either as parameters to in-built 
+        Kwargs to use for computing weighting, either as parameters to in-built
         functions or to be passed direct to a weighting callable.
     results_array : array-like, default None
         If not None, EMD values will be stored to this array. It should
@@ -641,20 +708,25 @@ def super_fast_EMD_matrix(grids,
     """
 
     shapes = np.array([i.shape for i in grids])
-    assert np.all(np.isclose(shapes, shapes[0])), "All GRIDs must have the same dimensions"
+    assert np.all(
+        np.isclose(shapes, shapes[0])
+    ), "All GRIDs must have the same dimensions"
 
-    if weighting == 'constant':
+    if weighting == "constant":
         # Use a constant weighting
         weights = np.ones(grids[0].shape[0])
-    elif weighting == 'power':
+    elif weighting == "power":
         # Use x**(-n)
-        assert 'n' in weighting_kwargs, "weighting_kwargs must contain `n` when weighting==power"
-        power_series = np.power(np.arange(1, grids[0].shape[0]+1), -weighting_kwargs['n'])
+        assert (
+            "n" in weighting_kwargs
+        ), "weighting_kwargs must contain `n` when weighting==power"
+        power_series = np.power(
+            np.arange(1, grids[0].shape[0] + 1), -weighting_kwargs["n"]
+        )
         # Normalise the weights to n_grid_shells
         weights = power_series * grids[0].shape[0] / power_series.sum()
     elif callable(weighting):
         weights = weighting(grids[0].shape[0], **weighting_kwargs)
-
 
     if not isinstance(grids, np.ndarray):
         grid_input = np.array(grids)
@@ -664,7 +736,9 @@ def super_fast_EMD_matrix(grids,
     # Perform cumulative summation for fast EMD calculation
     grid_cumsum = np.cumsum(grid_input, axis=-1)
 
-    assert np.all(np.isclose(grid_cumsum[0,0,-1], grid_cumsum[:,:,-1])), "All GRIDs must be normalised to the same area. "
+    assert np.all(
+        np.isclose(grid_cumsum[0, 0, -1], grid_cumsum[:, :, -1])
+    ), "All GRIDs must be normalised to the same area. "
 
     if results_array:
         assert results_array.shape == (grid_input.shape[0], grid_input.shape[0])
@@ -679,56 +753,66 @@ def super_fast_EMD_matrix(grids,
         output[i, :i] = output[:i, i]
     return output
 
-def rdf_emd_similarity(rdf_a, rdf_b, max_distance=10, method='fast'):
+
+def rdf_emd_similarity(rdf_a, rdf_b, max_distance=10, method="fast"):
     """
     Compute EMD similarity between two RDF distributions (1D or 2D)
-    
+
     Notes
     -----
-    
+
     This is the most time-consuming step in computing EMD similarity between distributions (particularly GRIDs).
     TODO: optimise this method further
-    
+
     The "fast" method joins all GRID shells into a single 1D vector, and uses a modified distance metric so that
     comparisons between equivalent shells will give the same EMD, but distributions between shells have a high EMD contribution
     (**unless the distributions are not normalised**). This requires only one call to `wasserstein_distance` (with n_shell*max_dist bins)
     rather than n_shell calls to `wasserstein_distance` (each with max_dist bins).
-    
+
     """
-    
+
     assert rdf_a.shape == rdf_b.shape
     emd_bins = np.linspace(0, max_distance, rdf_a.shape[-1])
-    
+
     if len(rdf_a.shape) == 2:
-        if method=='orig':
+        if method == "orig":
             shell_distances = []
             for j in range(rdf_a.shape[0]):
-                shell_distances.append(wasserstein_distance(emd_bins, emd_bins, 
-                                                            rdf_a[j], rdf_b[j]))
-                                                            
+                shell_distances.append(
+                    wasserstein_distance(emd_bins, emd_bins, rdf_a[j], rdf_b[j])
+                )
 
             return np.array(shell_distances).mean()
-        elif method=='fast':
-            assert np.isclose(rdf_a.sum(axis=1), 1.0).all(), "All GRID shells must be normalized to 1.0 in order for the fast method to work correctly."
-            assert np.isclose(rdf_b.sum(axis=1), 1.0).all(), "All GRID shells must be normalized to 1.0 in order for the fast method to work correctly."
+        elif method == "fast":
+            assert np.isclose(
+                rdf_a.sum(axis=1), 1.0
+            ).all(), "All GRID shells must be normalized to 1.0 in order for the fast method to work correctly."
+            assert np.isclose(
+                rdf_b.sum(axis=1), 1.0
+            ).all(), "All GRID shells must be normalized to 1.0 in order for the fast method to work correctly."
             shell_offsets = np.arange(0, rdf_a.shape[0]) * emd_bins[-1]
-            emd_bins_1D = (np.vstack([emd_bins]*rdf_a.shape[0]) + np.column_stack([shell_offsets] * rdf_a.shape[-1]))
+            emd_bins_1D = np.vstack([emd_bins] * rdf_a.shape[0]) + np.column_stack(
+                [shell_offsets] * rdf_a.shape[-1]
+            )
             if isinstance(rdf_a, np.ndarray) and isinstance(rdf_b, np.ndarray):
                 # Using standard NumPy array processing
                 emd_bins_1D = emd_bins_1D.ravel()
-                return wasserstein_distance(emd_bins_1D, emd_bins_1D, rdf_a.ravel(), rdf_b.ravel())
+                return wasserstein_distance(
+                    emd_bins_1D, emd_bins_1D, rdf_a.ravel(), rdf_b.ravel()
+                )
             elif isinstance(rdf_a, coo_matrix) and isinstance(rdf_b, coo_matrix):
                 # We are using sparse array, so can gain a significant speedup (~2-5-fold)
                 emd_bins_a = emd_bins_1D[rdf_a.row, rdf_a.col]
                 emd_bins_b = emd_bins_1D[rdf_b.row, rdf_b.col]
-                return wasserstein_distance(emd_bins_a, emd_bins_b, rdf_a.data, rdf_b.data)
+                return wasserstein_distance(
+                    emd_bins_a, emd_bins_b, rdf_a.data, rdf_b.data
+                )
     elif len(rdf_a.shape) == 1:
         return wasserstein_distance(emd_bins, emd_bins, rdf_a, rdf_b)
-                                                            
-    
-    
-def rdf_row_similarity(baseline_rdf, all_rdf, max_distance = 10):
-    '''
+
+
+def rdf_row_similarity(baseline_rdf, all_rdf, max_distance=10):
+    """
     Calculate the earth mover's distance between two RDFs
     Current support vanilla rdf and extend rdf
     Using Guassian smearing for rdf
@@ -739,40 +823,41 @@ def rdf_row_similarity(baseline_rdf, all_rdf, max_distance = 10):
     Return:
         a pandas dataframe of pairwise distance between baseline id and all others
         for multiple shells rdf the distance is the mean value of all shells
-    '''
+    """
     # used for wasserstein distance
     emd_bins = np.linspace(0, 10, 101)
 
     rdf_1 = baseline_rdf
-    rdf_emd = pd.DataFrame(columns=['baseline'])
+    rdf_emd = pd.DataFrame(columns=["baseline"])
 
     if len(rdf_1.shape) == 2:
         dist_matrix = dist_matrix_1d(len(rdf_1[0]))
         for d, rdf_2 in enumerate(all_rdf):
-            #rdf_len = np.array([len(rdf_1), len(rdf_2)]).min()
-            #shell_distances = []
-            #for j in range(rdf_len):
+            # rdf_len = np.array([len(rdf_1), len(rdf_2)]).min()
+            # shell_distances = []
+            # for j in range(rdf_len):
             #    shell_distances.append(wasserstein_distance(emd_bins, emd_bins, rdf_1[j], rdf_2[j]))
             #    #shell_distances.append(emd(rdf_1[j], rdf_2[j], dist_matrix))
-            #rdf_emd.loc[d] = np.array(shell_distances).mean()
+            # rdf_emd.loc[d] = np.array(shell_distances).mean()
             rdf_emd.loc[d] = rdf_emd_similarity(rdf_1, rdf_2, max_distance=max_distance)
 
     elif len(rdf_1.shape) == 1:
         dist_matrix = dist_matrix_1d(len(rdf_1))
         for d, rdf_2 in enumerate(all_rdf):
             rdf_emd.loc[d] = wasserstein_distance(emd_bins, emd_bins, rdf_1, rdf_2)
-            #rdf_emd.loc[d['task_id']] = emd(rdf_1, rdf_2, dist_matrix)
-    
+            # rdf_emd.loc[d['task_id']] = emd(rdf_1, rdf_2, dist_matrix)
+
     return rdf_emd
 
 
-def rdf_similarity_matrix(all_rdf,
-                          data=None,
-                          indice=None,
-                          method='emd',
-                          max_distance = 10,
-                          ):
-    '''
+def rdf_similarity_matrix(
+    all_rdf,
+    data=None,
+    indice=None,
+    method="emd",
+    max_distance=10,
+):
+    """
     Calculate the earth mover's distance between all RDF pairs, returning a square matrix.
 
     Parameters
@@ -796,30 +881,37 @@ def rdf_similarity_matrix(all_rdf,
     `rdf_similarity_matrix` has changed to use `super_fast_EMD_matrix` internally, which is better
     parallelised. More control over data storage (e.g. saving direct to a file to reduce memory) can
     be achieved by using `super_fast_EMD_matrix` directly.
-    '''
-    
-    warnings.warn('`rdf_similarity` is now effectively parallelised using numba, so indice is no longer used.', SyntaxWarning)
+    """
+
+    warnings.warn(
+        "`rdf_similarity` is now effectively parallelised using numba, so indice is no longer used.",
+        SyntaxWarning,
+    )
 
     rdf_lengths = [i.shape[0] for i in all_rdf]
-    assert len(set(rdf_lengths)) == 1, "All RDFs (or GRIDs) must have the same number of bins - use `data_prepare.trim_rdf_bins` first"
-    
+    assert (
+        len(set(rdf_lengths)) == 1
+    ), "All RDFs (or GRIDs) must have the same number of bins - use `data_prepare.trim_rdf_bins` first"
+
     # Compute bin_width based on max distance
     bin_width = max_distance / rdf_lengths[0]
 
     if len(all_rdf[0].shape) == 2:
         # typically for extend RDF
-        
+
         if data:
-            ids = [i['task_id'] for i in data]
+            ids = [i["task_id"] for i in data]
         else:
             ids = np.arange(len(all_rdf))
-        
-        dissimilarity = super_fast_EMD_matrix(all_rdf,
-                                              bin_width,
-                                              weighting='constant',
-                                              weighting_kwargs={'n':0.0},
-                                              results_array = None,)
-        
+
+        dissimilarity = super_fast_EMD_matrix(
+            all_rdf,
+            bin_width,
+            weighting="constant",
+            weighting_kwargs={"n": 0.0},
+            results_array=None,
+        )
+
         df = pd.DataFrame(dissimilarity, index=ids, columns=ids)
 
         # df = pd.DataFrame(np.zeros((len(ids), len(ids))), index=ids, columns=ids)
@@ -833,24 +925,30 @@ def rdf_similarity_matrix(all_rdf,
     elif len(all_rdf[0].shape) == 1:
         # typically for vanilla RDF and other 1D input
         df = pd.DataFrame([])
-        for i1 in tqdm(range(indice[0], indice[1]), desc='similarity matrix rows', mininterval=10):
+        for i1 in tqdm(
+            range(indice[0], indice[1]), desc="similarity matrix rows", mininterval=10
+        ):
             d1 = data[i1]
             for i2, d2 in enumerate(data):
                 if i1 <= i2:
-                    if method == 'emd':
-                        shell_distance = rdf_emd_similarity(all_rdf[i1], all_rdf[i2], max_distance=max_distance)
-                        
-                    elif method == 'cosine':
-                        shell_distance = spatial.distance.cosine(all_rdf[i1], all_rdf[i2])
+                    if method == "emd":
+                        shell_distance = rdf_emd_similarity(
+                            all_rdf[i1], all_rdf[i2], max_distance=max_distance
+                        )
 
-                    df.loc[d1['task_id'], d2['task_id']] = shell_distance
+                    elif method == "cosine":
+                        shell_distance = spatial.distance.cosine(
+                            all_rdf[i1], all_rdf[i2]
+                        )
+
+                    df.loc[d1["task_id"], d2["task_id"]] = shell_distance
                 else:
-                    df.loc[d1['task_id'], d2['task_id']] = np.nan
-    return df 
+                    df.loc[d1["task_id"], d2["task_id"]] = np.nan
+    return df
 
 
-def rdf_similarity_matrix_old(data, all_rdf, order=None, method='emd'):
-    '''
+def rdf_similarity_matrix_old(data, all_rdf, order=None, method="emd"):
+    """
     Deprecated. Have some methods there no longer used
         1. (reciprical) inner product as a similarity measure
         2. emd method implemented in pyemd
@@ -862,10 +960,10 @@ def rdf_similarity_matrix_old(data, all_rdf, order=None, method='emd'):
 
     Args:
         data: data from json
-        all_rdf: 
+        all_rdf:
         order: how the compounds are arranged
             None: using the order in the josn 'data'
-            symmetry: in the order of space group number, typically for 
+            symmetry: in the order of space group number, typically for
                 influence of distortion
             lattice: in the order of lattice constant
         method: how similarity is calculated
@@ -878,9 +976,12 @@ def rdf_similarity_matrix_old(data, all_rdf, order=None, method='emd'):
     Return:
         a pandas dataframe with all pairwise distance
         for multiple shells rdf the distance is the mean value of all shells
-    '''
+    """
 
-    warnings.warn("`rdf_similarity_matrix_old` is deprecated, and will be removed in a future release.", DeprecationWarning)
+    warnings.warn(
+        "`rdf_similarity_matrix_old` is deprecated, and will be removed in a future release.",
+        DeprecationWarning,
+    )
 
     # used for wasserstein distance
     emd_bins = np.linspace(0, 10, 101)
@@ -889,117 +990,138 @@ def rdf_similarity_matrix_old(data, all_rdf, order=None, method='emd'):
         # typically for extend RDF
         df = pd.DataFrame([])
         dist_matrix = dist_matrix_1d(len(all_rdf[0][0]))
-        for i1, d1 in enumerate(tqdm(data, desc='rdf similarity', mininterval=60)):
+        for i1, d1 in enumerate(tqdm(data, desc="rdf similarity", mininterval=60)):
             for i2, d2 in enumerate(data):
                 if i1 <= i2:
                     rdf_len = np.array([len(all_rdf[i1]), len(all_rdf[i2])]).min()
                     shell_distances = []
                     for j in range(rdf_len):
-                        if method == 'emd':
-                            #shell_distances.append(wasserstein_distance(emd_bins, emd_bins, 
+                        if method == "emd":
+                            # shell_distances.append(wasserstein_distance(emd_bins, emd_bins,
                             #                                            all_rdf[i1][j], all_rdf[i2][j]))
-                            shell_distances.append(emd(all_rdf[i1][j], all_rdf[i2][j], dist_matrix))
-                        elif method == 'linear' or method == 'linear-reciprocal':
-                            shell_distances.append(np.inner(all_rdf[i1][j], all_rdf[i2][j]))
-                        elif method == 'cosine' or method == 'cosine-reciprocal':
-                            shell_distances.append(spatial.distance.cosine(all_rdf[i1][j], all_rdf[i2][j]))
+                            shell_distances.append(
+                                emd(all_rdf[i1][j], all_rdf[i2][j], dist_matrix)
+                            )
+                        elif method == "linear" or method == "linear-reciprocal":
+                            shell_distances.append(
+                                np.inner(all_rdf[i1][j], all_rdf[i2][j])
+                            )
+                        elif method == "cosine" or method == "cosine-reciprocal":
+                            shell_distances.append(
+                                spatial.distance.cosine(all_rdf[i1][j], all_rdf[i2][j])
+                            )
 
-                    if method == 'emd' or method == 'linear' or method == 'cosine':
-                        df.loc[d1['task_id'], d2['task_id']] = np.array(shell_distances).mean()
-                        df.loc[d2['task_id'], d1['task_id']] = np.array(shell_distances).mean()
-                    elif method == 'linear-reciprocal' or method == 'cosine-reciprocal':
+                    if method == "emd" or method == "linear" or method == "cosine":
+                        df.loc[d1["task_id"], d2["task_id"]] = np.array(
+                            shell_distances
+                        ).mean()
+                        df.loc[d2["task_id"], d1["task_id"]] = np.array(
+                            shell_distances
+                        ).mean()
+                    elif method == "linear-reciprocal" or method == "cosine-reciprocal":
                         # add a small number 1e-11 to avoid dividing by zero
-                        df.loc[d1['task_id'], d2['task_id']] = 1.0 / (np.array(shell_distances).mean() + 1e-11)
-                        df.loc[d2['task_id'], d1['task_id']] = 1.0 / (np.array(shell_distances).mean() + 1e-11)    
+                        df.loc[d1["task_id"], d2["task_id"]] = 1.0 / (
+                            np.array(shell_distances).mean() + 1e-11
+                        )
+                        df.loc[d2["task_id"], d1["task_id"]] = 1.0 / (
+                            np.array(shell_distances).mean() + 1e-11
+                        )
 
     elif len(all_rdf[0].shape) == 1:
         # typically for vanilla RDF and other 1D input
         df = pd.DataFrame([])
         dist_matrix = dist_matrix_1d(len(all_rdf[0]))
-        for i1, d1 in enumerate(tqdm(data, desc='rdf similarity', mininterval=60)):
+        for i1, d1 in enumerate(tqdm(data, desc="rdf similarity", mininterval=60)):
             for i2, d2 in enumerate(data):
                 if i1 <= i2:
-                    if method == 'emd':
+                    if method == "emd":
                         # see above for explanation and comparision of these two methods
-                        shell_distance = wasserstein_distance(emd_bins, emd_bins, 
-                                                            all_rdf[i1], all_rdf[i2])
+                        shell_distance = wasserstein_distance(
+                            emd_bins, emd_bins, all_rdf[i1], all_rdf[i2]
+                        )
                         # shell_distance = emd(all_rdf[i1], all_rdf[i2], dist_matrix)
-                    elif method == 'linear' or method == 'cosine':
+                    elif method == "linear" or method == "cosine":
                         shell_distance = np.inner(all_rdf[i1], all_rdf[i2])
-                    elif method == 'linear-reciprocal' or method == 'cosine-reciprocal':
+                    elif method == "linear-reciprocal" or method == "cosine-reciprocal":
                         # add a small number 1e-11 to avoid dividing by zero
-                        shell_distance = 1.0 / (np.inner(all_rdf[i1], all_rdf[i2]) + 1e-11)
-                    df.loc[d1['task_id'], d2['task_id']] = shell_distance
-                    df.loc[d2['task_id'], d1['task_id']] = shell_distance    
-    
-    if order == 'symmetry':
-        df2 = pd.DataFrame(columns=['sg'])
+                        shell_distance = 1.0 / (
+                            np.inner(all_rdf[i1], all_rdf[i2]) + 1e-11
+                        )
+                    df.loc[d1["task_id"], d2["task_id"]] = shell_distance
+                    df.loc[d2["task_id"], d1["task_id"]] = shell_distance
+
+    if order == "symmetry":
+        df2 = pd.DataFrame(columns=["sg"])
         for d in data:
-            struct = Structure.from_str(d['cif'], fmt='cif')
-            df2.loc[d['task_id']] = struct.get_space_group_info()[1]
-        new_index = df2.sort_values('sg').index.values
+            struct = Structure.from_str(d["cif"], fmt="cif")
+            df2.loc[d["task_id"]] = struct.get_space_group_info()[1]
+        new_index = df2.sort_values("sg").index.values
 
         df = df.reindex(columns=new_index, index=new_index, fill_value=0)
         np.fill_diagonal(df.values, 0)
 
-    elif order == 'lattice':
-        df2 = pd.DataFrame(columns=['lattice'])
+    elif order == "lattice":
+        df2 = pd.DataFrame(columns=["lattice"])
         for d in data:
-            struct = Structure.from_str(d['cif'], fmt='cif')
-            df2.loc[d['task_id']] = struct.lattice.a
-        new_index = df2.sort_values('lattice').index.values
+            struct = Structure.from_str(d["cif"], fmt="cif")
+            df2.loc[d["task_id"]] = struct.lattice.a
+        new_index = df2.sort_values("lattice").index.values
 
         df = df.reindex(columns=new_index, index=new_index, fill_value=0)
         np.fill_diagonal(df.values, 0)
-    
-    return df 
+
+    return df
 
 
 def rdf_similarity_visualize(data, all_rdf, mode, base_id=31):
-    '''
+    """
     Visualization of rdf similarity results.
     Currently only used to investigate the influence of lattice constant
 
     Args:
         data: data from json
-        all_rdf: 
-        base_id: ID number for the baseline structure, i.e. all others structures are compared 
+        all_rdf:
+        base_id: ID number for the baseline structure, i.e. all others structures are compared
             to this structure
     Return:
         a pandas dataframe with all pairwise distance
         for multiple shells rdf the distance is the mean value of all shells
-    '''
+    """
 
     df = pd.DataFrame([])
-    if mode == 'similarity_different_shell':
+    if mode == "similarity_different_shell":
         vis_rdf_shells = [0, 2, 6, 12, 14, 20, 26, 28]
         for i2, d2 in enumerate(data):
             for j in vis_rdf_shells:
-                df.loc[d2['task_id'], str(j)] = wasserstein_distance(all_rdf[base_id][j], all_rdf[i2][j])
-    
-    elif mode == 'similarity_different_':
+                df.loc[d2["task_id"], str(j)] = wasserstein_distance(
+                    all_rdf[base_id][j], all_rdf[i2][j]
+                )
+
+    elif mode == "similarity_different_":
         dist_list = []
         mp_indice = []
         vis_ids = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
         for i2 in vis_ids:
-            mp_indice.append(data[i2]['task_id'])
+            mp_indice.append(data[i2]["task_id"])
 
             rdf_len = np.array([len(all_rdf[base_id]), len(all_rdf[i2])]).min()
             shell_distances = []
             for j in range(rdf_len):
-                shell_distances.append(wasserstein_distance(all_rdf[base_id][j], all_rdf[i2][j]))
+                shell_distances.append(
+                    wasserstein_distance(all_rdf[base_id][j], all_rdf[i2][j])
+                )
             dist_list.append(shell_distances)
 
         df = pd.DataFrame(dist_list, index=mp_indice).transpose()
-    
-    elif mode == 'rdf_shell':
+
+    elif mode == "rdf_shell":
         rdf0s = []
         local_extrems = [21, 25, 29, 31, 36, 40]
         for i in local_extrems:
             rdf0s.append(all_rdf[i][0])
         df = pd.DataFrame(rdf0s, index=local_extrems).transpose()
-    
-    elif mode == 'rdf_shell_emd_path':
+
+    elif mode == "rdf_shell_emd_path":
         emd_flows = []
         local_extrems = [21, 25, 29, 36, 40]
         dist_matrix = dist_matrix_1d(len(all_rdf[0][0]))
@@ -1009,134 +1131,167 @@ def rdf_similarity_visualize(data, all_rdf, mode, base_id=31):
             print(em[0], wasserstein_distance(all_rdf[base_id][0], all_rdf[i][0]))
             emd_flows.append(em[1])
         df = pd.DataFrame(emd_flows, index=local_extrems)
-    
-    elif mode == 'lattice_difference':
+
+    elif mode == "lattice_difference":
         nums = [0, 259, 544]
         for base_id in nums:
-            a1 = Structure.from_str(data[base_id]['cif'], fmt='cif').lattice.a
+            a1 = Structure.from_str(data[base_id]["cif"], fmt="cif").lattice.a
             for i2, d in enumerate(data):
-                a2 = Structure.from_str(data[i2]['cif'], fmt='cif').lattice.a
+                a2 = Structure.from_str(data[i2]["cif"], fmt="cif").lattice.a
                 rdf_len = np.array([len(all_rdf[base_id]), len(all_rdf[i2])]).min()
                 shell_distances = []
                 for j in range(rdf_len):
-                    shell_distances.append(wasserstein_distance(all_rdf[base_id][j], all_rdf[i2][j]))
-                df.loc[data[i2]['task_id'], data[base_id]['task_id'] + 'lattice'] = a1 - a2
-                df.loc[data[i2]['task_id'], data[base_id]['task_id']] = np.array(shell_distances).mean()
-    
+                    shell_distances.append(
+                        wasserstein_distance(all_rdf[base_id][j], all_rdf[i2][j])
+                    )
+                df.loc[data[i2]["task_id"], data[base_id]["task_id"] + "lattice"] = (
+                    a1 - a2
+                )
+                df.loc[data[i2]["task_id"], data[base_id]["task_id"]] = np.array(
+                    shell_distances
+                ).mean()
+
     return df
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Earth Mover Distance',
-                                    formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('--input_file', type=str, default='../MP_modulus.json',
-                        help='the bulk modulus and structure from Materials Project')
-    parser.add_argument('--output_file', type=str, default='',
-                        help='currently for rdf similarity')
-    parser.add_argument('--rdf_dir', type=str, default='./',
-                        help='dir has all the rdf files')
-    parser.add_argument('--simi_dir', type=str, default='./',
-                        help='dir containing distance matrices')                        
-    parser.add_argument('--task', type=str, default='rdf_similarity',
-                        help='which property to be calculated: \n' +
-                            '   rdf_similarity: \n' +
-                            '   rdf_similarity_matrix: \n' +
-                            '   composition_similarity_matrix: \n' +
-                            '   composition_similarity: \n' +
-                            '   rdf_similarity_visualize: \n' +
-                            '   find_same_structure: find all structures giving same rdf \n' +
-                            '   find_same_rdf: find all same rdf \n' +
-                            '   nn_bulk_modulus: predict bulk modulus using nearest neighbor \n' +
-                            '   '
-                      )
-    parser.add_argument('--baseline_id', type=str, default=None,
-                        help='only used for single rdf_similarity composition_similarity tasks')
-    parser.add_argument('--data_indice', type=str, default=None,
-                        help='start and end indice of the sub dataset')
-    parser.add_argument('-p', '--procs', type=int, default=None,
-                        help='Number of processors to parallelize over where implemented')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Earth Mover Distance",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "--input_file",
+        type=str,
+        default="../MP_modulus.json",
+        help="the bulk modulus and structure from Materials Project",
+    )
+    parser.add_argument(
+        "--output_file", type=str, default="", help="currently for rdf similarity"
+    )
+    parser.add_argument(
+        "--rdf_dir", type=str, default="./", help="dir has all the rdf files"
+    )
+    parser.add_argument(
+        "--simi_dir", type=str, default="./", help="dir containing distance matrices"
+    )
+    parser.add_argument(
+        "--task",
+        type=str,
+        default="rdf_similarity",
+        help="which property to be calculated: \n"
+        + "   rdf_similarity: \n"
+        + "   rdf_similarity_matrix: \n"
+        + "   composition_similarity_matrix: \n"
+        + "   composition_similarity: \n"
+        + "   rdf_similarity_visualize: \n"
+        + "   find_same_structure: find all structures giving same rdf \n"
+        + "   find_same_rdf: find all same rdf \n"
+        + "   nn_bulk_modulus: predict bulk modulus using nearest neighbor \n"
+        + "   ",
+    )
+    parser.add_argument(
+        "--baseline_id",
+        type=str,
+        default=None,
+        help="only used for single rdf_similarity composition_similarity tasks",
+    )
+    parser.add_argument(
+        "--data_indice",
+        type=str,
+        default=None,
+        help="start and end indice of the sub dataset",
+    )
+    parser.add_argument(
+        "-p",
+        "--procs",
+        type=int,
+        default=None,
+        help="Number of processors to parallelize over where implemented",
+    )
 
     args = parser.parse_args()
     input_file = args.input_file
-    output_file = args.output_file    
+    output_file = args.output_file
     rdf_dir = args.rdf_dir
     task = args.task
     baseline_id = args.baseline_id
     procs = args.procs
-    
+
     if isinstance(args.data_indice, str):
-        indice = list(map(int, args.data_indice.split('_')))
+        indice = list(map(int, args.data_indice.split("_")))
     else:
         indice = None
 
-    with open (input_file,'r') as f:
+    with open(input_file, "r") as f:
         data = json.load(f)
 
-    if task == 'rdf_similarity':
+    if task == "rdf_similarity":
         if procs is not None and procs > 1:
             all_rdf = rdf_read_parallel(data, rdf_dir, procs=procs)
         else:
             all_rdf = rdf_read(data, rdf_dir)
-        baseline_rdf = np.loadtxt(rdf_dir + '/' + baseline_id, delimiter=' ')
+        baseline_rdf = np.loadtxt(rdf_dir + "/" + baseline_id, delimiter=" ")
         rdf_emd = rdf_row_similarity(baseline_rdf, all_rdf)
-        rdf_emd.to_csv(output_file + baseline_id + '_rdf_emd.csv')
+        rdf_emd.to_csv(output_file + baseline_id + "_rdf_emd.csv")
 
-    elif task == 'rdf_similarity_matrix':
+    elif task == "rdf_similarity_matrix":
         if procs is not None and procs > 1:
             all_rdf = rdf_read_parallel(data, rdf_dir, procs=procs)
         else:
             all_rdf = rdf_read(data, rdf_dir)
 
-        df = rdf_similarity_matrix(all_rdf, data, indice=indice, method='emd')
-        df.to_csv(output_file + '_whole_matrix.csv')
+        df = rdf_similarity_matrix(all_rdf, data, indice=indice, method="emd")
+        df.to_csv(output_file + "_whole_matrix.csv")
 
-    elif task == 'composition_similarity':
+    elif task == "composition_similarity":
         elem_vectors, elem_symbols = composition_one_hot(data)
         compo_emd = composition_similarity(baseline_id, elem_vectors)
-        compo_emd.to_csv(output_file + baseline_id + '_compos_emd.csv')
+        compo_emd.to_csv(output_file + baseline_id + "_compos_emd.csv")
 
-    elif task == 'composition_similarity_matrix':
+    elif task == "composition_similarity_matrix":
         elem_vectors, elem_symbols = composition_one_hot(data)
         compo_emd = composition_similarity_matrix(elem_vectors, indice=indice)
         if indice:
-            compo_emd.to_csv(output_file + str(indice[0]) + '_' + str(indice[1]) + '.csv')
+            compo_emd.to_csv(
+                output_file + str(indice[0]) + "_" + str(indice[1]) + ".csv"
+            )
         else:
-            compo_emd.to_csv(output_file + '_whole_matrix.csv')
+            compo_emd.to_csv(output_file + "_whole_matrix.csv")
 
-    elif task == 'rdf_similarity_visualize':
+    elif task == "rdf_similarity_visualize":
         if procs is not None and procs > 1:
             all_rdf = rdf_read_parallel(data, rdf_dir, procs=procs)
         else:
             all_rdf = rdf_read(data, rdf_dir)
 
-        for mode in ['rdf_shell_emd_path']:
+        for mode in ["rdf_shell_emd_path"]:
             df = rdf_similarity_visualize(data, all_rdf, mode=mode)
-            df.to_csv(output_file + '_' + mode + '.csv')
+            df.to_csv(output_file + "_" + mode + ".csv")
 
-    elif task == 'find_same_structure':
+    elif task == "find_same_structure":
         match_list = find_same_structure(data)
-        with open(output_file, 'w') as f:
+        with open(output_file, "w") as f:
             json.dump(match_list, f, indent=1)
 
-    elif task == 'find_same_rdf':
+    elif task == "find_same_rdf":
         if procs is not None and procs > 1:
             all_rdf = rdf_read_parallel(data, rdf_dir, procs=procs)
         else:
             all_rdf = rdf_read(data, rdf_dir)
         all_rdf = rdf_trim(all_rdf)
         X_data = rdf_flatten(all_rdf)
-        match_list = find_same_rdf(all_rdf,data)
-        with open(output_file, 'w') as f:
+        match_list = find_same_rdf(all_rdf, data)
+        with open(output_file, "w") as f:
             json.dump(match_list, f, indent=1)
 
-    elif task == 'nn_bulk_modulus':
+    elif task == "nn_bulk_modulus":
         if baseline_id:
             # for single point calculation
-            mp_ids = os.listdir(os.path.join(sys.path[0], '../rdf_emd/'))
+            mp_ids = os.listdir(os.path.join(sys.path[0], "../rdf_emd/"))
             for f in mp_ids:
-                print(nn_bulk_modulus_single(f.replace('_emd.csv', ''), data))
+                print(nn_bulk_modulus_single(f.replace("_emd.csv", ""), data))
         else:
-            pred_k = nn_bulk_modulus_matrix_add(data, simi_matrix=['extended_rdf_emd', 'composition_emd'])
-            pred_k.to_csv(output_file + 'pred_k.csv')
-
-
+            pred_k = nn_bulk_modulus_matrix_add(
+                data, simi_matrix=["extended_rdf_emd", "composition_emd"]
+            )
+            pred_k.to_csv(output_file + "pred_k.csv")

--- a/src/gridrdf/earth_mover_distance.py
+++ b/src/gridrdf/earth_mover_distance.py
@@ -14,6 +14,7 @@ import sys
 import os
 import json
 import math
+from typing import Union
 import numpy as np
 import pandas as pd
 import argparse
@@ -485,7 +486,10 @@ def composition_similarity(baseline_id, data, index="z_number_78"):
 
 
 def composition_similarity_matrix(
-    data, indice=None, index="z_number_78", elem_similarity_file="similarity_matrix.csv"
+    data,
+    indice=None,
+    index="z_number_78",
+    elem_similarity: Union[pd.DataFrame, str] = "similarity_matrix.csv",
 ):
     """
     Calcalate pairwise earth mover's distance of all compositions, the composition should be
@@ -512,7 +516,10 @@ def composition_similarity_matrix(
         indice = [0, len(data)]
 
     dist = []
-    dist_matrix = pd.read_csv(elem_similarity_file, index_col="ionA")
+    if isinstance(elem_similarity, str):
+        dist_matrix = pd.read_csv(elem_similarity, index_col="ionA")
+    else:
+        dist_matrix = elem_similarity
     dist_matrix = 1 / (np.log10(1 / dist_matrix + 1))
 
     if index == "pettifor":


### PR DESCRIPTION
Related to #2. I applied [black formatting](https://black.readthedocs.io/en/stable/) first, but you can see the content changes in:

https://github.com/sparks-baird/gridrdf/compare/b0e49ae4bce3b563c7eacdcfca8abac4486efbf3...a79c381a8c4ca2ef999954cbe7cfb7c01ca40234

Basically all I did was rename `elem_similarity_file` to `elem_similarity` and change
```python
dist_matrix = pd.read_csv(elem_similarity_file, index_col="ionA")
```
to
```python
    if isinstance(elem_similarity, str):
        dist_matrix = pd.read_csv(elem_similarity, index_col="ionA")
    else:
        dist_matrix = elem_similarity
```

In a similar vein, it's usually not too difficult to include the data along with the Python package. The data would just need to be placed within `src/gridrdf` with an `__init__.py` file. Let's say you have the following file structure:
```python
src
  gridrdf
    data
      __init__.py
      similarity_matrix.csv
```

In the code, it can be imported like:
```python
from importlib.resources import open_text
from gridrdf import data
elem_similarity_csv = open_text(data, "similarity_matrix.csv")
elem_similarity = pd.read_csv(elem_similarity_csv)
```

Since you used PyScaffold, the other Python package setup should be handled natively via the template files. Lmk if you want a PR for that, too.

`mat_discover` is [an example of this](https://github.com/sparks-baird/mat_discover/blob/199b7771938fb7ab1f7a5218306cec97ce25b89f/mat_discover/utils/data.py#L3) where data could be placed in https://github.com/sparks-baird/mat_discover/tree/main/mat_discover/data

`crabnet` is a "real" example of this, where I include data with the Python package https://github.com/sparks-baird/CrabNet/tree/main/crabnet/data